### PR TITLE
Add comma between JSON objects

### DIFF
--- a/Output/PartAngleDisplay/PartAngleDisplay.version
+++ b/Output/PartAngleDisplay/PartAngleDisplay.version
@@ -12,7 +12,7 @@
 		"MAJOR":1,
 		"MINOR":2,
 		"PATCH":0
-	}
+	},
 	"KSP_VERSION_MAX":{
 		"MAJOR":1,
 		"MINOR":2,


### PR DESCRIPTION
JSON is very strict about syntax, and from these forum posts I understand this mod hasn't been getting pulled into the CKAN index lately. I think this missing comma is why.

- http://forum.kerbalspaceprogram.com/index.php?/topic/155998-122-astrogator-v020/&do=findComment&comment=2950443
- http://forum.kerbalspaceprogram.com/index.php?/topic/155998-122-astrogator-v020/&do=findComment&comment=2950453